### PR TITLE
Add a missing positional argument in player.stop()

### DIFF
--- a/pylav/extension/red/ui/buttons/player.py
+++ b/pylav/extension/red/ui/buttons/player.py
@@ -99,7 +99,7 @@ class StopTrackButton(discord.ui.Button):
             )
             return
 
-        await player.stop()
+        await player.stop(interaction.user)
         if notify_channel := await player.notify_channel():
             with contextlib.suppress(discord.HTTPException):
                 await notify_channel.send(


### PR DESCRIPTION
I realised after using `[p]plset stats` and trying to stop the player with the button, it doesn't stop and returned an error:
`TypeError: Player.stop() missing 1 required positional argument: 'requester'`

This PR will fix it, already tested it :p