### PR TITLE
Fix possible AttributeError in QueueSource

### DIFF
--- a/pylav/extension/red/ui/menus/queue.py
+++ b/pylav/extension/red/ui/menus/queue.py
@@ -289,6 +289,7 @@ class QueueMenu(BaseMenu):
             self.add_item(self.repeat_button_off)
 
     async def _no_player_or_no_dj(self):
+        self.queue_disconnect.disabled = True
         self.forward_button.disabled = True
         self.backward_button.disabled = True
         self.first_button.disabled = True

--- a/pylav/extension/red/ui/menus/queue.py
+++ b/pylav/extension/red/ui/menus/queue.py
@@ -261,6 +261,7 @@ class QueueMenu(BaseMenu):
         self.add_item(self.play_now_button)
 
     async def _player_and_dj(self, player: Player):
+        self.queue_disconnect.disabled = False
         if player.paused:
             self.add_item(self.resume_button)
         else:

--- a/pylav/extension/red/ui/sources/queue.py
+++ b/pylav/extension/red/ui/sources/queue.py
@@ -56,6 +56,7 @@ class SearchPickerSource(menus.ListPageSource):
 class QueueSource(menus.ListPageSource):
     def __init__(self, guild_id: int, cog: DISCORD_COG_TYPE, history: bool = False):  # noqa
         self.cog = cog
+        self.current_player = None
         self.per_page = 10
         self.guild_id = guild_id
         self.history = history
@@ -91,6 +92,7 @@ class QueueSource(menus.ListPageSource):
 
     async def format_page(self, menu: QueueMenu, tracks: list[Track]) -> discord.Embed:
         if player := self.cog.pylav.get_player(menu.ctx.guild.id):
+            self.current_player = player
             return (
                 await player.get_queue_page(
                     page_index=menu.current_page,
@@ -137,6 +139,7 @@ class QueuePickerSource(QueueSource):
 
     async def format_page(self, menu: QueuePickerMenu, tracks: list[Track]) -> discord.Embed:
         if player := self.cog.pylav.get_player(menu.ctx.guild.id):
+            self.current_player = player
             return (
                 await player.get_queue_page(
                     page_index=menu.current_page,

--- a/pylav/extension/red/ui/sources/queue.py
+++ b/pylav/extension/red/ui/sources/queue.py
@@ -91,29 +91,28 @@ class QueueSource(menus.ListPageSource):
         return start, page_num
 
     async def format_page(self, menu: QueueMenu, tracks: list[Track]) -> discord.Embed:
-        if player := self.cog.pylav.get_player(menu.ctx.guild.id):
-            self.current_player = player
-            return (
-                await player.get_queue_page(
-                    page_index=menu.current_page,
-                    per_page=self.per_page,
-                    total_pages=self.get_max_pages(),
-                    embed=True,
-                    messageable=menu.ctx,
-                    history=self.history,
-                )
-                if player.current and (player.history.size() if self.history else True)
-                else await self.cog.pylav.construct_embed(
-                    description=_("There's nothing in recently played")
-                    if self.history
-                    else _("There's nothing currently being played"),
-                    messageable=menu.ctx,
-                )
-            )
-        else:
+        if not (player := self.cog.pylav.get_player(menu.ctx.guild.id)):
             return await self.cog.pylav.construct_embed(
                 description=_("No active player found in server"), messageable=menu.ctx
             )
+        self.current_player = player
+        return (
+            await player.get_queue_page(
+                page_index=menu.current_page,
+                per_page=self.per_page,
+                total_pages=self.get_max_pages(),
+                embed=True,
+                messageable=menu.ctx,
+                history=self.history,
+            )
+            if player.current and (player.history.size() if self.history else True)
+            else await self.cog.pylav.construct_embed(
+                description=_("There's nothing in recently played")
+                if self.history
+                else _("There's nothing currently being played"),
+                messageable=menu.ctx,
+            )
+        )
 
 
 class QueuePickerSource(QueueSource):
@@ -138,23 +137,22 @@ class QueuePickerSource(QueueSource):
         return []
 
     async def format_page(self, menu: QueuePickerMenu, tracks: list[Track]) -> discord.Embed:
-        if player := self.cog.pylav.get_player(menu.ctx.guild.id):
-            self.current_player = player
-            return (
-                await player.get_queue_page(
-                    page_index=menu.current_page,
-                    per_page=self.per_page,
-                    total_pages=self.get_max_pages(),
-                    embed=True,
-                    messageable=menu.ctx,
-                )
-                if player.current
-                else await self.cog.pylav.construct_embed(
-                    description=_("There's nothing currently being played"),
-                    messageable=menu.ctx,
-                )
-            )
-        else:
+        if not (player := self.cog.pylav.get_player(menu.ctx.guild.id)):
             return await self.cog.pylav.construct_embed(
                 description=_("No active player found in server"), messageable=menu.ctx
             )
+        self.current_player = player
+        return (
+            await player.get_queue_page(
+                page_index=menu.current_page,
+                per_page=self.per_page,
+                total_pages=self.get_max_pages(),
+                embed=True,
+                messageable=menu.ctx,
+            )
+            if player.current
+            else await self.cog.pylav.construct_embed(
+                description=_("There's nothing currently being played"),
+                messageable=menu.ctx,
+            )
+        )


### PR DESCRIPTION
I found out another error in `[p]queue` actually, when I tried to disconnect the bot with the button menu, it returns this error:
`AttributeError: 'QueueSource' object has no attribute 'current_player'`

I also made the DisconnectButton disables when there's no player and re-enable it again when a player is found, this is to prevent `JobLookupError` when there's no player but the DisconnectButton was pressed.

This PR will fix it, no worries it's already tested :D