### PR TITLE
Node.get_filter_payload() unexpected keyword argument 'pluginFilters' (Low priority)

### DIFF
--- a/pylav/players/player.py
+++ b/pylav/players/player.py
@@ -2245,9 +2245,7 @@ class Player(VoiceProtocol):
                 "distortion": distortion or self.distortion or None,
                 "low_pass": low_pass or self.low_pass or None,
                 "channel_mix": channel_mix or self.channel_mix or None,
-                "pluginFilters": {
-                    "echo": echo or self.echo or None,
-                },
+                "echo": echo or self.echo or None,
             }
         if not volume:
             kwargs.pop("volume", None)
@@ -2281,9 +2279,7 @@ class Player(VoiceProtocol):
             "distortion": distortion,
             "low_pass": low_pass,
             "channel_mix": channel_mix,
-            "pluginFilters": {
-                "echo": echo,
-            },
+            "echo": echo,
         }
         if not equalizer:
             self._equalizer = self._equalizer.default()


### PR DESCRIPTION
I have no context for your intentions by choosing to wrap `"echo": echo` and `"echo": echo or self.echo or None` inside of `"pluginFilters": {}` but I found that it causes any `/fx <effect>` to throw errors in its current state.

## How to reproduce:
Using `/fx reset`, `/fx piano`, or any `/fx <effect>` results in this error to be thrown:

```
Exception in command 'fx reset'
Traceback (most recent call last):
  File "/data/venv/lib/python3.11/site-packages/discord/app_commands/commands.py", line 841, in _do_call
    return await self._callback(self.binding, interaction, **params)  # type: ignore
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/cogs/CogManager/cogs/pleffects/cog.py", line 914, in slash_fx_reset
    await context.player.set_filters(requester=context.author, reset_not_set=True)
  File "/data/venv/lib/python3.11/site-packages/pylav/players/player.py", line 2256, in set_filters
    "filters": self.node.get_filter_payload(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Node.get_filter_payload() got an unexpected keyword argument 'pluginFilters'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/data/venv/lib/python3.11/site-packages/discord/app_commands/tree.py", line 1248, in _call
    await command._invoke_with_namespace(interaction, namespace)
  File "/data/venv/lib/python3.11/site-packages/discord/app_commands/commands.py", line 867, in _invoke_with_namespace
    return await self._do_call(interaction, transformed_values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/venv/lib/python3.11/site-packages/discord/app_commands/commands.py", line 856, in _do_call
    raise CommandInvokeError(self, e) from e
discord.app_commands.errors.CommandInvokeError: Command 'reset' raised an exception: TypeError: Node.get_filter_payload() got an unexpected keyword argument 'pluginFilters'
```
## Workaround
<sub>I say workaround and not fix because obviously you had intentions by adding `"pluginFilters": {}`, but until those intentions see fruition these two changes will do.</sub>

 Removing `"echo": echo` and `"echo": echo or self.echo or None` from within `"pluginFilters": {}` results in `/fx reset` and the other `/fx <effect>` commands working as intended.

See ['Files changed'](https://github.com/PyLav/PyLav/pull/248/files).

## Extra notes:
- Pylav version: **1.10.10**
- PyLavEffects version: **1.0.0**
- Hardware: **Ubuntu w/ Docker**
- <sub><sub>I've never done a pull request in my life</sub></sub>
- <sub><sub>Sorry :)</sub></sub>
