### PR TITLE
No escaping bot activity strings

### DIFF
--- a/pylav/players/manager.py
+++ b/pylav/players/manager.py
@@ -367,6 +367,7 @@ class PlayerController:
                     max_length=40,
                     author=True,
                     unformatted=True,
+                    escape=False,
                 )
                 if activity and track_name in activity.name:
                     return


### PR DESCRIPTION
Just a one-line change, there's no need to escape activity strings as they don't have any formatting. Escaping it only causes there to be no separator between artist and track name which looks strange.
Works fine from my testing